### PR TITLE
Improve manual selection

### DIFF
--- a/facelib/LandmarksProcessor.py
+++ b/facelib/LandmarksProcessor.py
@@ -27,6 +27,15 @@ mean_face_y = np.array([
 
 landmarks_2D = np.stack( [ mean_face_x, mean_face_y ], axis=1 )
 
+# 68 point landmark definitions
+landmarks_68_pt = { "mouth": (48,68),
+                    "right_eyebrow": (17,22),
+                    "left_eyebrow": (22,27),
+                    "right_eye": (36,42),
+                    "left_eye": (42,48),
+                    "nose": (27,35),
+                    "jaw": (0,17) }
+
 def get_transform_mat (image_landmarks, output_size, face_type):
     if not isinstance(image_landmarks, np.ndarray):
         image_landmarks = np.array (image_landmarks) 
@@ -169,6 +178,13 @@ def draw_landmarks (image, image_landmarks, color):
         cv2.circle(image, (x, y), 2, color, -1)
         #text_color = colorsys.hsv_to_rgb ( (i%4) * (0.25), 1.0, 1.0 )
         #cv2.putText(image, str(i), (x, y), cv2.FONT_HERSHEY_SIMPLEX, 0.1,text_color,1)
+    if len(image_landmarks) == 68:
+        for feat,idx_range in landmarks_68_pt.items():
+            for idx in range( idx_range[0], idx_range[1] - 1 ):
+                pt1 = tuple(image_landmarks[idx])
+                pt2 = tuple(image_landmarks[idx + 1])
+                cv2.line( image, pt1, pt2, color )
+
         
 def draw_rect_landmarks (image, rect, image_landmarks, face_size, face_type):
     image_utils.draw_rect (image, rect, (255,0,0), 2 )

--- a/utils/SubprocessorBase.py
+++ b/utils/SubprocessorBase.py
@@ -75,7 +75,8 @@ class SubprocessorBase(object):
         return None
         
     def inc_progress_bar(self, c):
-        self.progress_bar.update(c)
+        self.progress_bar.n += c
+        self.progress_bar.refresh()
     
     def safe_print(self, msg):
         self.print_lock.acquire()


### PR DESCRIPTION
I thought that your Manual Extract widget was a great idea! I made some changes in my fork that you may want:

Lines are drawn for facial features. Previously it was difficult to tell if the point cloud of landmarks was correct or not because you didn't know what facial feature each point belonged to. Now you can see the face.

After confirming a frame, the next frame is displayed without moving the mouse. Previously you had to move the mouse before the window would update, making it difficult to keep the face in the same place between frames.

You can now go back and forth between frames to update previously selected faces.