### PR TITLE
update to Keras 2.2.2

### DIFF
--- a/facelib/LandmarksExtractor.py
+++ b/facelib/LandmarksExtractor.py
@@ -57,7 +57,7 @@ class LandmarksExtractor(object):
     def __init__ (self, keras):
         self.keras = keras
         K = self.keras.backend
-        class TorchBatchNorm2D(self.keras.engine.topology.Layer):
+        class TorchBatchNorm2D(self.keras.layers.Layer):
             def __init__(self, axis=-1, momentum=0.99, epsilon=1e-3, **kwargs):
                 super(TorchBatchNorm2D, self).__init__(**kwargs)
                 self.supports_masking = True

--- a/nnlib/__init__.py
+++ b/nnlib/__init__.py
@@ -84,10 +84,10 @@ def MSEMaskLossClass(keras):
     return MSEMaskLoss
     
 def PixelShufflerClass(keras):
-    class PixelShuffler(keras.engine.topology.Layer):
+    class PixelShuffler(keras.layers.Layer):
         def __init__(self, size=(2, 2), data_format=None, **kwargs):
             super(PixelShuffler, self).__init__(**kwargs)
-            self.data_format = keras.utils.conv_utils.normalize_data_format(data_format)
+            self.data_format = keras.backend.common.normalize_data_format(data_format)
             self.size = keras.utils.conv_utils.normalize_tuple(size, 2, 'size')
 
         def call(self, inputs):

--- a/requirements-gpu-cuda9-cudnn7.txt
+++ b/requirements-gpu-cuda9-cudnn7.txt
@@ -1,7 +1,7 @@
 pathlib==1.0.1
 scandir==1.6
 h5py==2.7.1
-Keras==2.1.6
+Keras==2.2.2
 opencv-python==3.4.0.12
 tensorflow-gpu==1.8.0
 scikit-image


### PR DESCRIPTION
Scripts currently fire ImportErrors related to Keras after a fresh install from the _requirements.txt_ file. This is because the keras-contrib library now requires Keras 2.2.2. To make this upgrade we must change the namespaces of the `Layer` object and `normalize_data_format` function. I have tested this change using all four main scripts and no other changes are required.