### PR TITLE
Added options --alpha and --transfercolor for converter

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-﻿import os
+import os
 import sys
 import argparse
 from utils import Path_utils
@@ -152,7 +152,9 @@ if __name__ == "__main__":
             masked_hist_match = arguments.masked_hist_match,
             erode_mask_modifier = arguments.erode_mask_modifier,
             blur_mask_modifier = arguments.blur_mask_modifier,
-            force_best_gpu_idx = arguments.force_best_gpu_idx
+            force_best_gpu_idx = arguments.force_best_gpu_idx,
+            alpha = arguments.alpha,
+            transfercolor = arguments.transfercolor,
             )
         
     convert_parser = subparsers.add_parser( "convert", help="Converter") 
@@ -167,6 +169,8 @@ if __name__ == "__main__":
     convert_parser.add_argument('--erode-mask-modifier', type=int, dest="erode_mask_modifier", default=0, help="Automatic erode mask modifier. Valid range [-100..100].")
     convert_parser.add_argument('--blur-mask-modifier', type=int, dest="blur_mask_modifier", default=0, help="Automatic blur mask modifier. Valid range [-100..200].")    
     convert_parser.add_argument('--debug', action="store_true", dest="debug", default=False, help="Debug converter.")
+    convert_parser.add_argument('--alpha', action="store_true", dest="alpha", default=False, help="export image with alpha channel.")
+    convert_parser.add_argument('--transfercolor', action="store_true", dest="transfercolor", default=False, help="transfer color from dst to merged.")
     convert_parser.add_argument('--force-best-gpu-idx', type=int, dest="force_best_gpu_idx", default=-1, help="Force to choose this GPU idx as best.")
     
     convert_parser.set_defaults(func=process_convert)

--- a/mainscripts/Converter.py
+++ b/mainscripts/Converter.py
@@ -1,4 +1,4 @@
-﻿import traceback
+import traceback
 from pathlib import Path
 from utils import Path_utils
 import cv2
@@ -64,13 +64,15 @@ from utils.SubprocessorBase import SubprocessorBase
 class ConvertSubprocessor(SubprocessorBase):
 
     #override
-    def __init__(self, converter, input_path_image_paths, output_path, alignments, debug): 
+    def __init__(self, converter, input_path_image_paths, output_path, alignments, debug, alpha, transfercolor): 
         super().__init__('Converter')    
         self.converter = converter
         self.input_path_image_paths = input_path_image_paths
         self.output_path = output_path
         self.alignments = alignments
         self.debug = debug
+        self.alpha = alpha
+        self.transfercolor = transfercolor
         
         self.input_data = self.input_path_image_paths
         self.files_processed = 0
@@ -156,7 +158,7 @@ class ConvertSubprocessor(SubprocessorBase):
             elif self.converter.get_mode() == ConverterBase.MODE_FACE:
                 faces = self.alignments[filename_path.stem]
                 for image_landmarks in faces:                
-                    image = self.converter.convert_face(image, image_landmarks, self.debug)     
+                    image = self.converter.convert_face(image, image_landmarks, self.debug, self.alpha, self.transfercolor)     
                     if self.debug:
                         for img in image:
                             cv2.imshow ('Debug convert', img )
@@ -183,6 +185,8 @@ def main (input_dir, output_dir, aligned_dir, model_dir, model_name, **in_option
     print ("Running converter.\r\n")
     
     debug = in_options['debug']
+    alpha = in_options['alpha']
+    transfercolor = in_options['transfercolor']
     
     try:
         input_path = Path(input_dir)
@@ -247,7 +251,10 @@ def main (input_dir, output_dir, aligned_dir, model_dir, model_name, **in_option
                     input_path_image_paths = Path_utils.get_image_paths(input_path), 
                     output_path            = output_path,
                     alignments             = alignments,                                     
-                    debug                  = debug ).process()
+                    debug                  = debug, 
+                    alpha                  = alpha,
+                    transfercolor          = transfercolor
+                    ).process()
                               
         model_sq.put ( {'op':'close'} )
         model_p.join()
@@ -279,5 +286,4 @@ def main (input_dir, output_dir, aligned_dir, model_dir, model_name, **in_option
     except Exception as e:
         print ( 'Error: %s' % (str(e)))
         traceback.print_exc()
-    
    

--- a/models/ConverterMasked.py
+++ b/models/ConverterMasked.py
@@ -55,7 +55,7 @@ class ConverterMasked(ConverterBase):
         self.predictor ( np.zeros ( (self.predictor_input_size,self.predictor_input_size,4), dtype=np.float32 ) )
         
     #override
-    def convert_face (self, img_bgr, img_face_landmarks, debug):        
+    def convert_face (self, img_bgr, img_face_landmarks, debug, alpha, transfercolor):        
         if debug:        
             debugs = [img_bgr.copy()]
 
@@ -187,6 +187,27 @@ class ConverterMasked(ConverterBase):
                 new_out = cv2.warpAffine( new_out_face_bgr, face_mat, img_size, img_bgr.copy(), cv2.WARP_INVERSE_MAP | cv2.INTER_LANCZOS4, cv2.BORDER_TRANSPARENT )
                 out_img =  np.clip( img_bgr*(1-img_mask_blurry_aaa) + (new_out*img_mask_blurry_aaa) , 0, 1.0 )
  
+            if transfercolor:                                              #making transfer color from original DST image to fake
+                from skimage import io, color
+                lab_clr = color.rgb2lab(img_bgr)                            #original DST, converting RGB to LAB color space
+                lab_bw = color.rgb2lab(out_img)                             #fake, converting RGB to LAB color space
+                tmp_channel, a_channel, b_channel = cv2.split(lab_clr)      #taking color channel A and B from original dst image
+                l_channel, tmp2_channel, tmp3_channel = cv2.split(lab_bw)   #taking lightness channel L from merged fake
+                img_LAB = cv2.merge((l_channel,a_channel, b_channel))       #merging light and color
+                out_img = color.lab2rgb(img_LAB)                            #converting LAB to RGB 
+                
+            if alpha:
+                new_image = out_img.copy()
+                new_image = (new_image*255).astype(np.uint8)                            #convert image to int
+                b_channel, g_channel, r_channel = cv2.split(new_image)                  #splitting RGB
+                alpha_channel = img_mask_blurry_aaa.copy()                              #making copy of alpha channel
+                alpha_channel = (alpha_channel*255).astype(np.uint8)
+                alpha_channel, tmp2, tmp3 = cv2.split(alpha_channel)                    #splitting alpha to three channels, they all same in original alpha channel, we need just one
+                img_BGRA = cv2.merge((b_channel,g_channel, r_channel, alpha_channel))   #mergin RGB with alpha
+                    
+                out_img = img_BGRA
+                out_img = out_img.astype(np.float32) / 255.0
+
         if debug:
             debugs += [out_img.copy()]
             


### PR DESCRIPTION
This allow to export png with alpha channel, and transfer color from DST original image to merged fake, using LAB color space.

**Warning! Added using skimage python module.**