### PR TITLE
Undefined name: import tensorflow as tf

### DIFF
--- a/utils/image_utils.py
+++ b/utils/image_utils.py
@@ -1,6 +1,7 @@
 import sys
 from utils import random_utils
 import numpy as np
+import tensorflow as tf
 import cv2
 import localization
 from scipy.spatial import Delaunay

--- a/utils/image_utils.py
+++ b/utils/image_utils.py
@@ -287,12 +287,9 @@ class TFLabConverter():
         
         self.lab_output_tensor = tf_rgb_to_lab()(self.bgr_input_tensor)        
         self.bgr_output_tensor = tf_lab_to_rgb()(self.lab_input_tensor)
-        
-        
-    def bgr2lab(self, bgr):    
+
+    def bgr2lab(self, bgr):
         return self.tf_sess.run(self.lab_output_tensor, feed_dict={self.bgr_input_tensor: bgr})
-        
-    def lab2bgr(self, lab):    
-        return self.tf_sess.run(self.bgr_output_tensor, feed_dict={self.lab_input_tensor: lab})    
-        
-    
+
+    def lab2bgr(self, lab):
+        return self.tf_sess.run(self.bgr_output_tensor, feed_dict={self.lab_input_tensor: lab})


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/iperov/DeepFaceLab on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./samples/Sample.py:47:41: F821 undefined name 'randint'
        return self.nearest_target_list[randint (0, len(self.nearest_target_list)-1)]                                        ^
./models/ConverterBase.py:25:16: F821 undefined name 'image'
        return image
               ^
./models/ConverterBase.py:32:16: F821 undefined name 'image'
        return image
               ^
./utils/image_utils.py:282:24: F821 undefined name 'tf_sess'
        self.tf_sess = tf_sess
                       ^
./utils/image_utils.py:284:33: F821 undefined name 'tf'
        self.bgr_input_tensor = tf.placeholder("float", [None, None, 3])
                                ^
./utils/image_utils.py:285:33: F821 undefined name 'tf'
        self.lab_input_tensor = tf.placeholder("float", [None, None, 3])
                                ^
./utils/image_utils.py:287:34: F821 undefined name 'tf_rgb_to_lab'
        self.lab_output_tensor = tf_rgb_to_lab()(self.bgr_input_tensor)        
                                 ^
./utils/image_utils.py:288:34: F821 undefined name 'tf_lab_to_rgb'
        self.bgr_output_tensor = tf_lab_to_rgb()(self.lab_input_tensor)
                                 ^
./nnlib/nnlib.py:509:28: F821 undefined name 'InstanceNormalization'
                    return InstanceNormalization (axis=3, gamma_initializer=RandomNormal(1., 0.02))(x)#GroupNormalization (axis=3, groups=K.int_shape (x)[3] // 4, gamma_initializer=RandomNormal(1., 0.02))(x)
                           ^
./nnlib/nnlib.py:509:77: F821 undefined name 'RandomNormal'
                    return InstanceNormalization (axis=3, gamma_initializer=RandomNormal(1., 0.02))(x)#GroupNormalization (axis=3, groups=K.int_shape (x)[3] // 4, gamma_initializer=RandomNormal(1., 0.02))(x)
                                                                            ^
./nnlib/nnlib.py:513:28: F821 undefined name 'BatchNormalization'
                    return BatchNormalization (axis=3, gamma_initializer=RandomNormal(1., 0.02))(x)
                           ^
./nnlib/nnlib.py:513:74: F821 undefined name 'RandomNormal'
                    return BatchNormalization (axis=3, gamma_initializer=RandomNormal(1., 0.02))(x)
                                                                         ^
./nnlib/nnlib.py:515:171: F821 undefined name 'RandomNormal'
            def Conv2D (filters, kernel_size, strides=(1, 1), padding='valid', data_format=None, dilation_rate=(1, 1), activation=None, use_bias=True, kernel_initializer=RandomNormal(0, 0.02), bias_initializer='zeros', kernel_regularizer=None, bias_regularizer=None, activity_regularizer=None, kernel_constraint=None, bias_constraint=None):
                                                                                                                                                                          ^
./nnlib/nnlib.py:516:24: F821 undefined name 'keras'
                return keras.layers.convolutional.Conv2D( filters=filters, kernel_size=kernel_size, strides=strides, padding=padding, data_format=data_format, dilation_rate=dilation_rate, activation=activation, use_bias=use_bias, kernel_initializer=kernel_initializer, bias_initializer=bias_initializer, kernel_regularizer=kernel_regularizer, bias_regularizer=bias_regularizer, activity_regularizer=activity_regularizer, kernel_constraint=kernel_constraint, bias_constraint=bias_constraint )
                       ^
./nnlib/nnlib.py:519:24: F821 undefined name 'keras'
                return keras.layers.Conv2DTranspose(filters=filters, kernel_size=kernel_size, strides=strides, padding=padding, output_padding=output_padding, data_format=data_format, dilation_rate=dilation_rate, activation=activation, use_bias=use_bias, kernel_initializer=kernel_initializer, bias_initializer=bias_initializer, kernel_regularizer=kernel_regularizer, bias_regularizer=bias_regularizer, activity_regularizer=activity_regularizer, kernel_constraint=kernel_constraint, bias_constraint=bias_constraint)
                       ^
./nnlib/nnlib.py:528:29: F821 undefined name 'ReflectionPadding2D'
                        x = ReflectionPadding2D((1,1))(x)
                            ^
./nnlib/nnlib.py:531:29: F821 undefined name 'ReLU'
                        x = ReLU()(x)
                            ^
./nnlib/nnlib.py:534:33: F821 undefined name 'Dropout'
                            x = Dropout(0.5)(x)
                                ^
./nnlib/nnlib.py:536:29: F821 undefined name 'ReflectionPadding2D'
                        x = ReflectionPadding2D((1,1))(x)
                            ^
./nnlib/nnlib.py:539:29: F821 undefined name 'ReLU'
                        x = ReLU()(x)       
                            ^
./nnlib/nnlib.py:540:32: F821 undefined name 'Add'
                        return Add()([x,input])            
                               ^
./nnlib/nnlib.py:545:21: F821 undefined name 'ReflectionPadding2D'
                x = ReflectionPadding2D((3,3))(x)
                    ^
./nnlib/nnlib.py:548:21: F821 undefined name 'ReLU'
                x = ReLU()(XNormalization(Conv2D(ngf*2, 4, 2, 'same')(x)))
                    ^
./nnlib/nnlib.py:549:21: F821 undefined name 'ReLU'
                x = ReLU()(XNormalization(Conv2D(ngf*4, 4, 2, 'same')(x)))
                    ^
./nnlib/nnlib.py:554:21: F821 undefined name 'ReLU'
                x = ReLU()(XNormalization(PixelShuffler()(Conv2D(ngf*2 *4, 3, 1, 'same')(x))))
                    ^
./nnlib/nnlib.py:554:43: F821 undefined name 'PixelShuffler'
                x = ReLU()(XNormalization(PixelShuffler()(Conv2D(ngf*2 *4, 3, 1, 'same')(x))))
                                          ^
./nnlib/nnlib.py:555:21: F821 undefined name 'ReLU'
                x = ReLU()(XNormalization(PixelShuffler()(Conv2D(ngf   *4, 3, 1, 'same')(x))))
                    ^
./nnlib/nnlib.py:555:43: F821 undefined name 'PixelShuffler'
                x = ReLU()(XNormalization(PixelShuffler()(Conv2D(ngf   *4, 3, 1, 'same')(x))))
                                          ^
./nnlib/nnlib.py:557:21: F821 undefined name 'ReflectionPadding2D'
                x = ReflectionPadding2D((3,3))(x)
                    ^
./nnlib/nnlib.py:559:21: F821 undefined name 'tanh'
                x = tanh(x)
                    ^
./nnlib/nnlib.py:577:28: F821 undefined name 'InstanceNormalization'
                    return InstanceNormalization (axis=3, gamma_initializer=RandomNormal(1., 0.02))(x)#GroupNormalization (axis=3, groups=K.int_shape (x)[3] // 4, gamma_initializer=RandomNormal(1., 0.02))(x)
                           ^
./nnlib/nnlib.py:577:77: F821 undefined name 'RandomNormal'
                    return InstanceNormalization (axis=3, gamma_initializer=RandomNormal(1., 0.02))(x)#GroupNormalization (axis=3, groups=K.int_shape (x)[3] // 4, gamma_initializer=RandomNormal(1., 0.02))(x)
                                                                            ^
./nnlib/nnlib.py:581:28: F821 undefined name 'BatchNormalization'
                    return BatchNormalization (axis=3, gamma_initializer=RandomNormal(1., 0.02))(x)
                           ^
./nnlib/nnlib.py:581:74: F821 undefined name 'RandomNormal'
                    return BatchNormalization (axis=3, gamma_initializer=RandomNormal(1., 0.02))(x)
                                                                         ^
./nnlib/nnlib.py:583:171: F821 undefined name 'RandomNormal'
            def Conv2D (filters, kernel_size, strides=(1, 1), padding='valid', data_format=None, dilation_rate=(1, 1), activation=None, use_bias=True, kernel_initializer=RandomNormal(0, 0.02), bias_initializer='zeros', kernel_regularizer=None, bias_regularizer=None, activity_regularizer=None, kernel_constraint=None, bias_constraint=None):
                                                                                                                                                                          ^
./nnlib/nnlib.py:584:24: F821 undefined name 'keras'
                return keras.layers.convolutional.Conv2D( filters=filters, kernel_size=kernel_size, strides=strides, padding=padding, data_format=data_format, dilation_rate=dilation_rate, activation=activation, use_bias=use_bias, kernel_initializer=kernel_initializer, bias_initializer=bias_initializer, kernel_regularizer=kernel_regularizer, bias_regularizer=bias_regularizer, activity_regularizer=activity_regularizer, kernel_constraint=kernel_constraint, bias_constraint=bias_constraint )
                       ^
./nnlib/nnlib.py:587:24: F821 undefined name 'keras'
                return keras.layers.Conv2DTranspose(filters=filters, kernel_size=kernel_size, strides=strides, padding=padding, output_padding=output_padding, data_format=data_format, dilation_rate=dilation_rate, activation=activation, use_bias=use_bias, kernel_initializer=kernel_initializer, bias_initializer=bias_initializer, kernel_regularizer=kernel_regularizer, bias_regularizer=bias_regularizer, activity_regularizer=activity_regularizer, kernel_constraint=kernel_constraint, bias_constraint=bias_constraint)
                       ^
./nnlib/nnlib.py:593:57: F821 undefined name 'ReflectionPadding2D'
                    x = Conv2D(inner_nc, 4, 2, 'valid')(ReflectionPadding2D( (1,1) )(x))
                                                        ^
./nnlib/nnlib.py:595:25: F821 undefined name 'ReLU'
                    x = ReLU()(x)
                        ^
./nnlib/nnlib.py:603:29: F821 undefined name 'ReLU'
                        x = ReLU()(x)
                            ^
./nnlib/nnlib.py:607:37: F821 undefined name 'Dropout'
                                x = Dropout(0.5)(x)
                                    ^
./nnlib/nnlib.py:609:29: F821 undefined name 'Concatenate'
                        x = Concatenate(axis=3)([inp, x])
                            ^
./nnlib/nnlib.py:612:29: F821 undefined name 'tanh'
                        x = tanh(x)   
                            ^
./nnlib/nnlib.py:641:21: F821 undefined name 'Concatenate'
                x = Concatenate(axis=3)([ past_2_image_tensor, past_1_image_tensor ])
                    ^
./nnlib/nnlib.py:655:28: F821 undefined name 'InstanceNormalization'
                    return InstanceNormalization (axis=3, gamma_initializer=RandomNormal(1., 0.02))(x)#GroupNormalization (axis=3, groups=K.int_shape (x)[3] // 4, gamma_initializer=RandomNormal(1., 0.02))(x)
                           ^
./nnlib/nnlib.py:655:77: F821 undefined name 'RandomNormal'
                    return InstanceNormalization (axis=3, gamma_initializer=RandomNormal(1., 0.02))(x)#GroupNormalization (axis=3, groups=K.int_shape (x)[3] // 4, gamma_initializer=RandomNormal(1., 0.02))(x)
                                                                            ^
./nnlib/nnlib.py:659:28: F821 undefined name 'BatchNormalization'
                    return BatchNormalization (axis=3, gamma_initializer=RandomNormal(1., 0.02))(x)
                           ^
./nnlib/nnlib.py:659:74: F821 undefined name 'RandomNormal'
                    return BatchNormalization (axis=3, gamma_initializer=RandomNormal(1., 0.02))(x)
                                                                         ^
./nnlib/nnlib.py:661:171: F821 undefined name 'RandomNormal'
            def Conv2D (filters, kernel_size, strides=(1, 1), padding='valid', data_format=None, dilation_rate=(1, 1), activation=None, use_bias=True, kernel_initializer=RandomNormal(0, 0.02), bias_initializer='zeros', kernel_regularizer=None, bias_regularizer=None, activity_regularizer=None, kernel_constraint=None, bias_constraint=None):
                                                                                                                                                                          ^
./nnlib/nnlib.py:662:24: F821 undefined name 'keras'
                return keras.layers.convolutional.Conv2D( filters=filters, kernel_size=kernel_size, strides=strides, padding=padding, data_format=data_format, dilation_rate=dilation_rate, activation=activation, use_bias=use_bias, kernel_initializer=kernel_initializer, bias_initializer=bias_initializer, kernel_regularizer=kernel_regularizer, bias_regularizer=bias_regularizer, activity_regularizer=activity_regularizer, kernel_constraint=kernel_constraint, bias_constraint=bias_constraint )
                       ^
./nnlib/nnlib.py:667:21: F821 undefined name 'ZeroPadding2D'
                x = ZeroPadding2D((1,1))(x)
                    ^
./nnlib/nnlib.py:669:21: F821 undefined name 'LeakyReLU'
                x = LeakyReLU(0.2)(x)
                    ^
./nnlib/nnlib.py:672:25: F821 undefined name 'ZeroPadding2D'
                    x = ZeroPadding2D((1,1))(x)
                        ^
./nnlib/nnlib.py:675:25: F821 undefined name 'LeakyReLU'
                    x = LeakyReLU(0.2)(x)
                        ^
./nnlib/nnlib.py:677:21: F821 undefined name 'ZeroPadding2D'
                x = ZeroPadding2D((1,1))(x)
                    ^
./nnlib/nnlib.py:680:21: F821 undefined name 'LeakyReLU'
                x = LeakyReLU(0.2)(x)
                    ^
./nnlib/nnlib.py:682:21: F821 undefined name 'ZeroPadding2D'
                x = ZeroPadding2D((1,1))(x)
                    ^
57    F821 undefined name 'image'
57
```

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree