### PR TITLE
Extended infos in training preview window

### DIFF
--- a/mainscripts/Trainer.py
+++ b/mainscripts/Trainer.py
@@ -21,11 +21,11 @@ def trainerThread (input_queue, output_queue, training_data_src_dir, training_da
             model_path = Path(model_path)
             
             if not training_data_src_path.exists():
-                print( 'Training data src directory is not exists.')
+                print( 'Training data src directory does not exist.')
                 return
                 
             if not training_data_dst_path.exists():
-                print( 'Training data dst directory is not exists.')
+                print( 'Training data dst directory does not exist.')
                 return
                 
             if not model_path.exists():

--- a/models/ModelBase.py
+++ b/models/ModelBase.py
@@ -118,6 +118,7 @@ class ModelBase(object):
         
         nnlib.import_all ( nnlib.DeviceConfig(allow_growth=False, force_gpu_idx=self.force_gpu_idx, **in_options) )
         self.device_config = nnlib.active_DeviceConfig
+        self.nnlib = nnlib;
 
         self.onInitialize(**in_options)
         


### PR DESCRIPTION
Hi iperov,

i think it would be really useful to see the model settings in screenshots of the training preview window.
Useful for you to track down problems, which are reported in some board, but also useful for the users.
I often saw screenshots with good training results and wanted to know, which settings has been used.

I did my best to write nice and understandable code.
But coming from Perl and C++, i'm a total newbie writing Python.
So please be patient with me, if i coded something really stupid ;)

Batch size 1
![image](https://user-images.githubusercontent.com/47699661/53124234-26c12900-355b-11e9-9b41-9877e45e1577.png)

Batch size 4
![image](https://user-images.githubusercontent.com/47699661/53124249-2e80cd80-355b-11e9-9480-cf7816d34555.png)
