### PR TITLE
New sharpness estimation based on laplacian operator

### DIFF
--- a/mainscripts/Sorter.py
+++ b/mainscripts/Sorter.py
@@ -21,17 +21,8 @@ def estimate_sharpness(image):
     
     if image.ndim == 3:
         image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
-
-    sharpness = 0
-    for y in range(height):
-        for x in range(width-1):        
-            sharpness += abs( int(image[y, x]) - int(image[y, x+1]) )            
-    
-    for x in range(width):    
-        for y in range(height-1):
-            sharpness += abs( int(image[y, x]) - int(image[y+1, x]) )
-    
-    return sharpness
+   
+    return cv2.Laplacian(image, cv2.CV_64F).var()
     
 
 class BlurEstimatorSubprocessor(Subprocessor):
@@ -54,9 +45,6 @@ class BlurEstimatorSubprocessor(Subprocessor):
                 
             if dflimg is not None:
                 image = cv2_imread( str(filepath) )
-                image = ( image * \
-                          LandmarksProcessor.get_image_hull_mask (image.shape, dflimg.get_landmarks()) \
-                         ).astype(np.uint8)
                 return [ str(filepath), estimate_sharpness( image ) ]
             else:
                 self.log_err ("%s is not a dfl image file" % (filepath.name) ) 

--- a/mainscripts/Sorter.py
+++ b/mainscripts/Sorter.py
@@ -1,4 +1,4 @@
-﻿import os
+import os
 import sys
 import operator
 import numpy as np
@@ -21,8 +21,17 @@ def estimate_sharpness(image):
     
     if image.ndim == 3:
         image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
-   
-    return cv2.Laplacian(image, cv2.CV_64F).var()
+
+    sharpness = 0
+    for y in range(height):
+        for x in range(width-1):        
+            sharpness += abs( int(image[y, x]) - int(image[y, x+1]) )            
+    
+    for x in range(width):    
+        for y in range(height-1):
+            sharpness += abs( int(image[y, x]) - int(image[y+1, x]) )
+    
+    return sharpness
     
 
 class BlurEstimatorSubprocessor(Subprocessor):
@@ -45,6 +54,9 @@ class BlurEstimatorSubprocessor(Subprocessor):
                 
             if dflimg is not None:
                 image = cv2_imread( str(filepath) )
+                image = ( image * \
+                          LandmarksProcessor.get_image_hull_mask (image.shape, dflimg.get_landmarks()) \
+                         ).astype(np.uint8)
                 return [ str(filepath), estimate_sharpness( image ) ]
             else:
                 self.log_err ("%s is not a dfl image file" % (filepath.name) ) 


### PR DESCRIPTION
BlurEstimatorSubprocessor now uses the full aligned image for sharpness estimation instead of the masked image
estimate_sharpness now calculates the variance of the laplacian operator. 

see here: https://www.pyimagesearch.com/2015/09/07/blur-detection-with-opencv/

In my opinion the old estimation algorithm was not reliable enough and produced false results too often while being slow. This new estimation based on the laplacian operator still produces false positives/negatives but as far as I could test, the results are far better. Even if this version is not better, it is at least faster (>800it/sec) :-) 