### PR TITLE
Raise python minimum version

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,8 +6,8 @@ from utils import Path_utils
 from utils import os_utils
 from pathlib import Path
 
-if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and sys.version_info[1] < 2):
-    raise Exception("This program requires at least Python 3.2")
+if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and sys.version_info[1] < 6):
+    raise Exception("This program requires at least Python 3.6")
 
 class fixPathAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):


### PR DESCRIPTION
S3FD extractor does not work with versions of Python lower than 3.6 throwing tuple out of range errors. Using anything lower may cause random hangs in DeepFaceLab. Since I last checked, the DFL Windows Binary should ship Python3.6 so I don't think this is a problem to raise the minimum version. 