### PR TITLE
Partial Python 3.7 Support

### DIFF
--- a/utils/iter_utils.py
+++ b/utils/iter_utils.py
@@ -48,6 +48,11 @@ class SubprocessGenerator(object):
     def __iter__(self):
         return self
 
+    def __getstate__(self):
+        self_dict = self.__dict__.copy()
+        del self_dict['p']
+        return self_dict
+
     def __next__(self):
         if self.p == None:
             user_param = self.user_param


### PR DESCRIPTION
Seems to be some pickling errors when trying to pass around a multiprocessing.Process object in Python 3.7. I don't fully understand why this works in Python 3.6. This fix should be backwards compatible with Python 3.6, however I have not tested it on Windows.

This isn't a current problem, but if DeepFaceLab wants to upgrade Python versions at some point, then this would be a necessary fix. 

I only consider this partial because the default Tensorflow shipped is Tensorflow 12.0, which unless using a custom build will not work with Python 3.7. However, it does work with Tensorflow 13, but then we run into the batch size regression. 

Anyways, let me know what you think. 

Referenced issue: 
https://github.com/iperov/DeepFaceLab/issues/194