### PR TITLE
Startup Fix for Linux

### DIFF
--- a/mainscripts/Trainer.py
+++ b/mainscripts/Trainer.py
@@ -12,7 +12,7 @@ import cv2
 import models
 from interact import interact as io
 
-def trainerThread (s2c, c2s, args, device_args):
+def trainerThread (s2c, c2s, e, args, device_args):
     while True:
         try:
             start_time = time.time()
@@ -66,6 +66,7 @@ def trainerThread (s2c, c2s, args, device_args):
                 else:
                     previews = [( 'debug, press update for new', model.debug_one_iter())]
                     c2s.put ( {'op':'show', 'previews': previews} )
+                e.set() #Set the GUI Thread as Ready
 
 
             if model.is_first_run():
@@ -189,8 +190,11 @@ def main(args, device_args):
     s2c = queue.Queue()
     c2s = queue.Queue()
 
-    thread = threading.Thread(target=trainerThread, args=(s2c, c2s, args, device_args) )
+    e = threading.Event()
+    thread = threading.Thread(target=trainerThread, args=(s2c, c2s, e, args, device_args) )
     thread.start()
+
+    e.wait() #Wait for inital load to occur.
 
     if no_preview:
         while True:
@@ -291,7 +295,7 @@ def main(args, device_args):
 
             key_events = io.get_key_events(wnd_name)
             key, chr_key, ctrl_pressed, alt_pressed, shift_pressed = key_events[-1] if len(key_events) > 0 else (0,0,False,False,False)
-            
+
             if key == ord('\n') or key == ord('\r'):
                 s2c.put ( {'op': 'close'} )
             elif key == ord('s'):


### PR DESCRIPTION
A while back I fixed the issue in DeepFaceLab on Linux where the startup time took literal minutes, sometimes multiple hours on multiple machines. This is due to a spinlock in the trainer script, and because threads are handled differently on Linux, this causes undesirable behavior.

~~I believe this fix works on Windows, but I need additional testing from a Windows user.~~ (EDIT: I've tested and it works fine)

The fix looks a bit ugly, but it works. I'm open for alternative ideas on how to handle this. 

