### PR TITLE
Missing imports: threading for line 26 and time for lines 73, 99, 107

### DIFF
--- a/samplelib/SampleGeneratorFacePerson.py
+++ b/samplelib/SampleGeneratorFacePerson.py
@@ -143,10 +143,10 @@ class SampleGeneratorFacePerson(SampleGeneratorBase):
 
         if self.debug:
             self.generators_count = 1
-            self.generators = [iter_utils.ThisThreadGenerator ( self.batch_func, (samples_host.create_cli(), index2d_host.create_cli(),) )]
+            self.generators = [ThisThreadGenerator ( self.batch_func, (samples_host.create_cli(), index2d_host.create_cli(),) )]
         else:
             self.generators_count = np.clip(multiprocessing.cpu_count(), 2, 4)
-            self.generators = [iter_utils.SubprocessGenerator ( self.batch_func, (samples_host.create_cli(), index2d_host.create_cli(),) ) for i in range(self.generators_count) ]
+            self.generators = [SubprocessGenerator ( self.batch_func, (samples_host.create_cli(), index2d_host.create_cli(),) ) for i in range(self.generators_count) ]
 
         self.generator_counter = -1
 

--- a/samplelib/SampleGeneratorFacePerson.py
+++ b/samplelib/SampleGeneratorFacePerson.py
@@ -1,5 +1,7 @@
 import copy
 import multiprocessing
+import threading
+import time
 import traceback
 
 import cv2


### PR DESCRIPTION
Missing imports:
* `import threading` for line 26 and
* `import time` for lines 73, 99, 107
* iter_utils is gone. Match function calls with the imports done on line 11.