### PR TITLE
Fix mixed up links

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,11 +224,11 @@ Unfortunately, there is no "make everything ok" button in DeepFaceLab. You shoul
 </td><td align="center">How to create the right faceset</td></tr>
 
 <tr><td align="right">
-<a href="https://mrdeepfakes.com/forums/thread-deepfacelab-2-0-compositing-in-davinci-resolve-vegas-pro-and-after-effects">Google Colab guide</a>
+<a href="https://mrdeepfakes.com/forums/thread-guide-deepfacelab-google-colab-tutorial">Google Colab guide</a>
 </td><td align="center">Guide how to train the fake on Google Colab</td></tr>
 
 <tr><td align="right">
-<a href="https://mrdeepfakes.com/forums/thread-guide-deepfacelab-google-colab-tutorial">Compositing</a>
+<a href="https://mrdeepfakes.com/forums/thread-deepfacelab-2-0-compositing-in-davinci-resolve-vegas-pro-and-after-effects">Compositing</a>
 </td><td align="center">To achieve the highest quality, compose deepfake manually in video editors such as Davinci Resolve or Adobe AfterEffects</td></tr>
 
 <tr><td align="right">


### PR DESCRIPTION
The URLs for Google Colab guide and Compositing are mixed up.