### PR TITLE
tensorflow-gpu 2.4.0 depends on h5py~=2.10.0

### DIFF
--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -1,6 +1,6 @@
 tqdm
 numpy==1.19.3
-h5py==2.9.0
+h5py==2.10.0
 opencv-python==4.1.0.25
 ffmpeg-python==0.1.17
 scikit-image==0.14.2


### PR DESCRIPTION
ERROR: Cannot install -r ./DeepFaceLab/requirements-cuda.txt (line 9) and h5py==2.9.0 because these package versions have conflicting dependencies.   

The conflict is caused by:
    The user requested h5py==2.9.0
    tensorflow-gpu 2.4.0 depends on h5py~=2.10.0