### PR TITLE
fix regression in nn.py

### DIFF
--- a/core/leras/nn.py
+++ b/core/leras/nn.py
@@ -115,7 +115,7 @@ class nn():
             nn.tf_sess_config = config
             
         if nn.tf_sess is None:
-            nn.tf_sess = tf.Session(config=nn.tf_sess_config)
+            nn.tf_sess = nn.tf.Session(config=nn.tf_sess_config)
 
         if floatx == "float32":
             floatx = nn.tf.float32


### PR DESCRIPTION
Hi

I think there is a regression in core/leras/nn.py

line 118 should be :
`nn.tf_sess = nn.tf.Session(config=nn.tf_sess_config)`

instead of
`nn.tf_sess = tf.Session(config=nn.tf_sess_config)`

https://github.com/iperov/DeepFaceLab/blob/292b562eb787a77256ba72664e15979ba553c81f/core/leras/nn.py#L118

error reported in merge action :
> UnboundLocalError: local variable 'tf' referenced before assignment