### PR TITLE
Refactor Qt Wrappers

### DIFF
--- a/XSegEditor/QCursorDB.py
+++ b/XSegEditor/QCursorDB.py
@@ -1,6 +1,6 @@
-from PyQt5.QtCore import *
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import *
+from PySide6.QtCore import *
+from PySide6.QtGui import *
+from PySide6.QtWidgets import *
                                        
 class QCursorDB():
     @staticmethod

--- a/XSegEditor/QIconDB.py
+++ b/XSegEditor/QIconDB.py
@@ -1,6 +1,6 @@
-from PyQt5.QtCore import *
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import *
+from PySide6.QtCore import *
+from PySide6.QtGui import *
+from PySide6.QtWidgets import *
 
 
 class QIconDB():

--- a/XSegEditor/QImageDB.py
+++ b/XSegEditor/QImageDB.py
@@ -1,6 +1,6 @@
-from PyQt5.QtCore import *
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import *
+from PySide6.QtCore import *
+from PySide6.QtGui import *
+from PySide6.QtWidgets import *
 
 class QImageDB():
     @staticmethod

--- a/XSegEditor/XSegEditor.py
+++ b/XSegEditor/XSegEditor.py
@@ -12,9 +12,9 @@ from types import SimpleNamespace as sn
 import cv2
 import numpy as np
 import numpy.linalg as npla
-from PyQt5.QtCore import *
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import *
+from PySide6.QtCore import *
+from PySide6.QtGui import *
+from PySide6.QtWidgets import *
 
 from core import imagelib, pathex
 from core.cv2ex import *
@@ -152,9 +152,9 @@ class CanvasConfig():
 
         if color_schemes is None:
             color_schemes = [
-                    ColorScheme( QColor(192,0,0,alpha=0), QColor(192,0,0,alpha=72), QColor(192,0,0), 2, QColor(255,255,255), QCursorDB.cross_red ),
-                    ColorScheme( QColor(0,192,0,alpha=0), QColor(0,192,0,alpha=72), QColor(0,192,0), 2, QColor(255,255,255), QCursorDB.cross_green ),
-                    ColorScheme( QColor(0,0,192,alpha=0), QColor(0,0,192,alpha=72), QColor(0,0,192), 2, QColor(255,255,255), QCursorDB.cross_blue ),
+                    ColorScheme( QColor(192,0,0), QColor(192,0,0), QColor(192,0,0), 2, QColor(255,255,255), QCursorDB.cross_red ),
+                    ColorScheme( QColor(0,192,0), QColor(0,192,0), QColor(0,192,0), 2, QColor(255,255,255), QCursorDB.cross_green ),
+                    ColorScheme( QColor(0,0,192), QColor(0,0,192), QColor(0,0,192), 2, QColor(255,255,255), QCursorDB.cross_blue ),
                     ]
         self.color_schemes = color_schemes
 
@@ -941,7 +941,6 @@ class QCanvasOperator(QWidget):
         qp = self.qp
         qp.begin(self)
         qp.setRenderHint(QPainter.Antialiasing)
-        qp.setRenderHint(QPainter.HighQualityAntialiasing)
         qp.setRenderHint(QPainter.SmoothPixmapTransform)
 
         src_rect = QRect(0, 0, *self.img_size)

--- a/core/imagelib/warp.py
+++ b/core/imagelib/warp.py
@@ -143,7 +143,7 @@ def gen_warp_params (w, flip=False, rotation_range=[-10,10], scale_range=[-0.5, 
     ################
     
     #random transform
-    random_transform_mat = cv2.getRotationMatrix2D((w // 2, w // 2), rotation, scale)
+    random_transform_mat = cv2.getRotationMatrix2D((int(w // 2), int(w // 2)), rotation, scale)
     random_transform_mat[:, 2] += (tx*w, ty*w)
 
     params = dict()

--- a/core/leras/device.py
+++ b/core/leras/device.py
@@ -46,7 +46,7 @@ class Devices(object):
         idx_mem = 0
         for device in self.devices:
             mem = device.total_mem
-            if mem > idx_mem:
+            if mem >= idx_mem:
                 result = device
                 idx_mem = mem
         return result
@@ -56,7 +56,7 @@ class Devices(object):
         idx_mem = sys.maxsize
         for device in self.devices:
             mem = device.total_mem
-            if mem < idx_mem:
+            if mem <= idx_mem:
                 result = device
                 idx_mem = mem
         return result

--- a/core/leras/nn.py
+++ b/core/leras/nn.py
@@ -112,6 +112,7 @@ class nn():
                 
             config.gpu_options.force_gpu_compatible = True
             config.gpu_options.allow_growth = True
+            config.allow_soft_placement = True
             nn.tf_sess_config = config
             
         if nn.tf_sess is None:

--- a/core/qtex/QSubprocessor.py
+++ b/core/qtex/QSubprocessor.py
@@ -3,9 +3,9 @@ import sys
 import time
 import traceback
 
-from PyQt5.QtCore import *
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import *
+from PySide6.QtCore import *
+from PySide6.QtGui import *
+from PySide6.QtWidgets import *
 
 from core.interact import interact as io
 

--- a/core/qtex/QXIconButton.py
+++ b/core/qtex/QXIconButton.py
@@ -1,6 +1,6 @@
-from PyQt5.QtCore import *
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import *
+from PySide6.QtCore import *
+from PySide6.QtGui import *
+from PySide6.QtWidgets import *
 
 from localization import StringsDB
 from .QXMainWindow import *

--- a/core/qtex/QXMainWindow.py
+++ b/core/qtex/QXMainWindow.py
@@ -1,6 +1,6 @@
-from PyQt5.QtCore import *
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import *
+from PySide6.QtCore import *
+from PySide6.QtGui import *
+from PySide6.QtWidgets import *
 
 class QXMainWindow(QWidget):
     """

--- a/core/qtex/qtex.py
+++ b/core/qtex/qtex.py
@@ -1,7 +1,7 @@
 import numpy as np
-from PyQt5.QtCore import *
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import *
+from PySide6.QtCore import *
+from PySide6.QtGui import *
+from PySide6.QtWidgets import *
 from localization import StringsDB
 
 from .QXMainWindow import *

--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -8,5 +8,5 @@ scikit-image==0.14.2
 scipy==1.4.1
 colorama
 tensorflow-gpu==2.4.0
-pyqt5
+pysides6
 tf2onnx==1.9.3


### PR DESCRIPTION
This PR drops in pyside6 which has better platform support than pyqt.

This change allows DFLive to function on a greater variety of linux systems, as well as OSX M1.

get_best_device and get_worst_device are updated to deal with the condition where CPU memory equals GPU memory on M1 architecture. 

`config.allow_soft_placement = True` allows the random uniform initializer to be run on CPU, otherwise this fails (I'm guessing this routine is not yet implemented on tensorflow-metal)