### PR TITLE
Performance: replace a slow numpy function

### DIFF
--- a/samplelib/SampleLoader.py
+++ b/samplelib/SampleLoader.py
@@ -15,6 +15,24 @@ from facelib import FaceType, LandmarksProcessor
 from .Sample import Sample, SampleType
 
 
+def load_face_sample(image_path):
+    dflimg = DFLIMG.load(Path(image_path))
+
+    if dflimg is None or not dflimg.has_data():
+        print(f"FaceSamplesLoader: {image_path} is not a dfl image file.")
+        data = None
+    else:
+        data = (dflimg.get_face_type(),
+                dflimg.get_shape(),
+                dflimg.get_landmarks(),
+                dflimg.get_seg_ie_polys(),
+                dflimg.get_xseg_mask_compressed(),
+                dflimg.get_eyebrows_expand_mod(),
+                dflimg.get_source_filename())
+
+    return image_path, data
+
+
 class SampleLoader:
     samples_cache = dict()
     @staticmethod
@@ -71,7 +89,10 @@ class SampleLoader:
 
     @staticmethod
     def load_face_samples ( image_paths):
-        result = FaceSamplesLoaderSubprocessor(image_paths).run()
+        #result = FaceSamplesLoaderSubprocessor(image_paths).run()
+        print("Loading samples...")
+        with multiprocessing.Pool() as pool:
+            result = pool.map(load_face_sample, image_paths)
         sample_list = []
 
         for filename, data in result:

--- a/samplelib/SampleProcessor.py
+++ b/samplelib/SampleProcessor.py
@@ -64,20 +64,24 @@ class SampleProcessor(object):
                     if xseg_mask.shape[0] != h or xseg_mask.shape[1] != w:
                         xseg_mask = cv2.resize(xseg_mask, (w,h), interpolation=cv2.INTER_CUBIC)                    
                         xseg_mask = imagelib.normalize_channels(xseg_mask, 1)
-                    return np.clip(xseg_mask, 0, 1)
+                    np.minimum(1, np.maximum(xseg_mask, 0, out=xseg_mask), out=xseg_mask)
+                    return xseg_mask
                 else:
                     full_face_mask = LandmarksProcessor.get_image_hull_mask (sample_bgr.shape, sample_landmarks, eyebrows_expand_mod=sample.eyebrows_expand_mod )
-                    return np.clip(full_face_mask, 0, 1)
+                    np.minimum(1, np.maximum(full_face_mask, 0, out=full_face_mask), out=full_face_mask)
+                    return full_face_mask
                 
             def get_eyes_mask():
                 eyes_mask = LandmarksProcessor.get_image_eye_mask (sample_bgr.shape, sample_landmarks)
-                return np.clip(eyes_mask, 0, 1)
+                np.minimum(1, np.maximum(eyes_mask, 0, out=eyes_mask), out=eyes_mask)
+                return eyes_mask
             
             def get_eyes_mouth_mask():                
                 eyes_mask = LandmarksProcessor.get_image_eye_mask (sample_bgr.shape, sample_landmarks)
                 mouth_mask = LandmarksProcessor.get_image_mouth_mask (sample_bgr.shape, sample_landmarks)
-                mask = eyes_mask + mouth_mask
-                return np.clip(mask, 0, 1)
+                eyes_mouth_mask = eyes_mask + mouth_mask
+                np.minimum(1, np.maximum(eyes_mouth_mask, 0, out=eyes_mouth_mask), out=eyes_mouth_mask)
+                return eyes_mouth_mask
                 
             is_face_sample = sample_landmarks is not None
 


### PR DESCRIPTION
This change will reduce the CPU load for GPU-bound tasks or the iteration time for CPU-bound tasks.

According to a [doc](https://numpy.org/doc/1.19/reference/generated/numpy.clip.html), **np.clip** is an 

> Equivalent to but faster than np.minimum(a_max, np.maximum(a, a_min))

But https://github.com/numpy/numpy/issues/14281 and some simple tests show the opposite result. I did this check with a CPU-bound (i5-3570K, 4.4GHz) SAEHD 96 training on the pretain_faces dataset:
```
@echo off
call _internal\setenv.bat

python "%DFL_ROOT%\main.py" train ^
    --training-data-src-dir ".\_internal\pretrain_faces" ^
    --training-data-dst-dir ".\_internal\pretrain_faces" ^
    --pretraining-data-dir "%INTERNAL%\pretrain_faces" ^
    --model-dir "%WORKSPACE%\model" ^
    --model SAEHD

pause
```
And got this:
**np.clip()**
143.4s per 300it = 478ms/it

**np.clip() to a same array**
142.8s per 300it = 476ms/it

**np.minimum() + np.maximum() to a same array**
119.5s per 300it = 398ms/it

[arrays check](https://gist.github.com/Cregrant/d1f7956cd564ee39258d1dba82be69cb)
CPU load reduced by 16%