### PR TITLE
DirectML plugin support in Tensorflow 2

### DIFF
--- a/requirements-dml.txt
+++ b/requirements-dml.txt
@@ -1,0 +1,13 @@
+tqdm
+numpy==1.20.1
+numexpr
+h5py==2.10.0
+opencv-python==4.3.0.38
+ffmpeg-python==0.1.17
+scikit-image==0.14.2
+scipy==1.4.1
+colorama
+tensorflow-cpu==2.10.0
+pyqt5
+tf2onnx
+tensorflow-directml-plugin


### PR DESCRIPTION
The existing version of DFL w/ DirectML is using a fork of Tensorflow 1.15 w/ DirectML support. The performance of this approach is less than ideal, as @iperov pointed out in this issue https://github.com/microsoft/DirectML/issues/108.

Since then, DirectML team has introduced a `tensorflow-directml-plugin`, which incorporates Pluggable Device API in Tensorflow 2, to provide an easier and faster way of leveraging DirectML in Tensorflow.

This PR introduces `tensorflow-directml-plugin` to DFL, without any significant changes to the existing models/scripts.

With brief benchmarks on my system (Ryzen 3600/Intel Arc A750 8GB/Windows 11/miniconda Python 3.7), I'm seeing
-  **45%** faster in Quick96 (`189ms`->`130ms`)
- **133%** faster in AMP (`2475ms`->`1060ms`)

If you want to try it yourself, you can follow the instructions below:
1. Download RTX30 series bundle of DFL
2. Download the executable here: https://github.com/brucehsu/DeepFaceLab/releases/tag/dml_plugin
3. Extract it to `_internal` directory of your DFL environment
4. Use DFL scripts as usual