### PR TITLE
Replaced the source of the Queen Elizabeth video with a new one 

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ DeepFaceLab is used by such popular youtube channels as
 
 <img src="doc/political_speech2.jpg" align="center">
 
-![](doc/youtube_icon.png) https://www.youtube.com/watch?v=IvY-Abd2FfM
+![](doc/youtube_icon.png) https://www.youtube.com/watch?v=yyFQPjIrnQE
 
 <img src="doc/political_speech3.jpg" align="center">
 


### PR DESCRIPTION
Replaced the source of the Queen Elizabeth video with a new one in the Read.me since the video from the old source has been made private and is no longer available to the public. Closes issues #5660